### PR TITLE
Fix broken Discord link and revert to original tagline

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -310,7 +310,7 @@ function CallToAction() {
                             <Link to="/docs/intro">Documentation</Link>
                             <Link to="/api">API Reference</Link>
                             <Link href="https://github.com/kapetan-io/querator">GitHub</Link>
-                            <Link href="https://discord.gg/gQeRm48R">Discord</Link>
+                            <Link href="https://discord.gg/XwfBdN9wdg">Discord</Link>
                             <Link href="https://trello.com/b/cey2cB3i/querator">Trello Board</Link>
                         </div>
                         <div className={styles.footerCopyright}>


### PR DESCRIPTION
### Purpose
Fix the broken Discord link and revert to the original tagline while maintaining the improved social card configuration.

### Implementation
- Updated Discord link to working invitation
- Reverted tagline to original "The reliable queue system that scales from prototype to production without the complexity"
- Reverted homepage title to "Almost Exactly Once Message Queue" for consistency
- Kept social card improvements and meta tag enhancements
- Maintained improved content structure and messaging

🤖 Generated with [Claude Code](https://claude.ai/code)